### PR TITLE
fix: allow completing interactively without prefix

### DIFF
--- a/yasnippet-capf.el
+++ b/yasnippet-capf.el
@@ -119,8 +119,9 @@ If INTERACTIVE is nil the function acts like a Capf."
   (if interactive
       (let ((completion-at-point-functions #'yasnippet-capf))
         (or (completion-at-point) (user-error "yasnippet-capf: No completions")))
-    (when (thing-at-point-looking-at "\\(?:\\sw\\|\\s_\\)+")
-      `(,(match-beginning 0) ,(match-end 0)
+    (let ((bounds (or (bounds-of-thing-at-point 'symbol)
+                      (cons (point) (point)))))
+      `(,(car bounds) ,(cdr bounds)
         ,(completion-table-with-cache
           (lambda (input)
             (yasnippet-capf-candidates input)))

--- a/yasnippet-capf.el
+++ b/yasnippet-capf.el
@@ -119,7 +119,7 @@ If INTERACTIVE is nil the function acts like a Capf."
   (if interactive
       (let ((completion-at-point-functions #'yasnippet-capf))
         (or (completion-at-point) (user-error "yasnippet-capf: No completions")))
-    (let ((bounds (or (bounds-of-thing-at-point 'symbol)
+    (when-let ((bounds (or (bounds-of-thing-at-point 'word)
                       (cons (point) (point)))))
       `(,(car bounds) ,(cdr bounds)
         ,(completion-table-with-cache


### PR DESCRIPTION
Hi. This PR addresses https://github.com/elken/yasnippet-capf/issues/4 and brings `yasnippet-capf` more in-line in this regard to the cape capfs:
![image](https://github.com/elken/yasnippet-capf/assets/29102529/876e08f3-337b-4354-90d6-4dbfdeeffce4)
