### PR TITLE
fix: ensure a space between candidate & annotation

### DIFF
--- a/yasnippet-capf.el
+++ b/yasnippet-capf.el
@@ -38,12 +38,19 @@
   "The method in which to lookup candidates by."
   :type '(choice
           (const :tag "Key" key)
-          (const :tag "Name" name)))
+          (const :tag "Name" name))
+  :group 'yasnippet-capf)
+
+(defcustom yasnippet-capf-annotation-prefix "  "
+  "The prefix to use for the annotation."
+  :type 'string
+  :group 'yasnippet-capf)
 
 (defvar yasnippet-capf--properties
   (list :annotation-function (lambda (snippet)
-                               (concat " " (get-text-property 0 'yas-annotation
-                                                              snippet)))
+                               (concat yasnippet-capf-annotation-prefix
+                                       (get-text-property 0 'yas-annotation
+                                                          snippet)))
         :company-kind (lambda (_) 'snippet)
         :company-doc-buffer #'yasnippet-capf--doc-buffer
         :exit-function (lambda (_ status)

--- a/yasnippet-capf.el
+++ b/yasnippet-capf.el
@@ -41,7 +41,9 @@
           (const :tag "Name" name)))
 
 (defvar yasnippet-capf--properties
-  (list :annotation-function (lambda (snippet) (get-text-property 0 'yas-annotation snippet))
+  (list :annotation-function (lambda (snippet)
+                               (concat " " (get-text-property 0 'yas-annotation
+                                                              snippet)))
         :company-kind (lambda (_) 'snippet)
         :company-doc-buffer #'yasnippet-capf--doc-buffer
         :exit-function (lambda (_ status)


### PR DESCRIPTION
Ensure there is at least a single space between the completion candidates and their annotations.

EDIT: I have just increased the default to 2 spaces and made that prefix customizable.