### PR TITLE
fix: clear overlays when erasing the doc buffer

### DIFF
--- a/yasnippet-capf.el
+++ b/yasnippet-capf.el
@@ -58,6 +58,7 @@ Returns a buffer to be displayed by popupinfo."
              (template (get-text-property 0 'yas-template cand)))
     (with-current-buffer (get-buffer-create "*yasnippet-capf-doc*")
       (erase-buffer)
+      (remove-overlays)
       (yas-minor-mode)
       (insert "Expands to:" ?\n ?\n)
       (condition-case error


### PR DESCRIPTION
Previously, the doc buffer would not clear the overlays when it was switching between different snippets. This would cause `yas--advance-end-maybe-previous-fields` to fail its `cl-assert` and consequently no popup would show.

Maybe with this we can also re-add my previous PR!