### PR TITLE
Reapply "fix: allow completing interactively without prefix (#15)"

### DIFF
--- a/yasnippet-capf.el
+++ b/yasnippet-capf.el
@@ -121,8 +121,9 @@ If INTERACTIVE is nil the function acts like a Capf."
   (if interactive
       (let ((completion-at-point-functions #'yasnippet-capf))
         (or (completion-at-point) (user-error "yasnippet-capf: No completions")))
-    (when (thing-at-point-looking-at "\\(?:\\sw\\|\\s_\\)+")
-      `(,(match-beginning 0) ,(match-end 0)
+    (when-let ((bounds (or (bounds-of-thing-at-point 'word)
+                      (cons (point) (point)))))
+      `(,(car bounds) ,(cdr bounds)
         ,(completion-table-with-cache
           (lambda (input)
             (yasnippet-capf-candidates input)))


### PR DESCRIPTION
This reverts commit db12b55cd08b614cbba134008566e48d7faf660e.

Let's get this code change back in. Hopefully with the last fix, we won't have any more problems. If we do, ping me with the info and I will fix it. This commit is really important because it allows us to auto-complete snippets without a prefix, just like how `company-yasnippet` lets us.